### PR TITLE
Add test imports for platform-specific modules

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -44,6 +44,7 @@ test:
     - vispy
     # make sure that platform-specific dpi functions can be imported
     - vispy.util.dpi
+    - vispy.util.fonts
   # TODO: check headless testing
   # requires:
   #  - pyqt >=5.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,6 +42,8 @@ requirements:
 test:
   imports:
     - vispy
+    # make sure that platform-specific dpi functions can be imported
+    - vispy.util.dpi
   # TODO: check headless testing
   # requires:
   #  - pyqt >=5.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - ctypes_fontconfig.diff
 
 build:
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:


### PR DESCRIPTION
This is a test based on https://github.com/vispy/vispy/pull/2137. Basically, I think we should have caught some of these build errors already. The conda-forge versions of python and build environments may be "smarter" and have bug fixes that cause these imports to not break, but regardless we should test them.

This new import test includes the `dpi` module which has platform-specific imports that on a Mac end up including cocoapy.py.

Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
